### PR TITLE
feat: added emulator with different sizes

### DIFF
--- a/mentorApp/lib/Navigation/AppController.dart
+++ b/mentorApp/lib/Navigation/AppController.dart
@@ -1,8 +1,8 @@
 import 'package:curved_navigation_bar/curved_navigation_bar.dart';
 import 'package:flutter/material.dart';
-import "./Profile/UserProfile.dart";
-import './Dashboard/Dashboard.dart';
-import "./Chat/Chat.dart";
+import "../Profile/UserProfile.dart";
+import '../Dashboard/Dashboard.dart';
+import "../Chat/Chat.dart";
 
 class AppController extends StatefulWidget {
     @override _MyAppState createState() => _MyAppState();

--- a/mentorApp/lib/Navigation/Root.dart
+++ b/mentorApp/lib/Navigation/Root.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'AppController.dart';
+import '../FTU/SignUp.dart';
+
+class Root extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+        title: 'MentorApp',
+        initialRoute: '/',
+        routes: {
+          '/': (context) => FirstRoute(),
+          '/second': (context) => SecondRoute(),
+          '/UserProfile': (context) => AppController(),
+        },
+      );
+    }
+  }

--- a/mentorApp/lib/main.dart
+++ b/mentorApp/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:device_simulator/device_simulator.dart';
 import 'package:flutter/material.dart';
-import 'FTU/SignUp.dart';
-import 'AppController.dart';
+import "./Navigation/Root.dart";
 
 const bool debugEnableDeviceSimulator = false;
 
@@ -15,26 +14,12 @@ class App extends StatelessWidget {
         home: DeviceSimulator(
           brightness: Brightness.dark, 
           enable: debugEnableDeviceSimulator, 
-          child: MaterialApp(title: 'MentorApp',
-            initialRoute: '/',
-            routes: {
-              '/': (context) => FirstRoute(),
-              '/second': (context) => SecondRoute(),
-              '/UserProfile': (context) => AppController(),
-            }
-          )
+          child: Root()
         )
       ) 
-    :
-      MaterialApp(
-        title: 'MentorApp',
-        initialRoute: '/',
-        routes: {
-          '/': (context) => FirstRoute(),
-          '/second': (context) => SecondRoute(),
-          '/UserProfile': (context) => AppController(),
-        },
-      );
+    : 
+      Root();
+
     return app;
   }
 }

--- a/mentorApp/lib/main.dart
+++ b/mentorApp/lib/main.dart
@@ -1,24 +1,41 @@
+import 'package:device_simulator/device_simulator.dart';
 import 'package:flutter/material.dart';
 import 'FTU/SignUp.dart';
 import 'AppController.dart';
+
+const bool debugEnableDeviceSimulator = false;
 
 void main() => runApp(App()); 
 
 class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'MentorApp',
-      //home: AppController(),
-      initialRoute: '/',
-      routes: {
-      // When navigating to the "/" route, build the FirstScreen widget.
-      '/': (context) => FirstRoute(),
-      // When navigating to the "/second" route, build the SecondScreen widget.
-      '/second': (context) => SecondRoute(),
-      '/UserProfile': (context) => AppController(),
-      },
-    );
+    final app = debugEnableDeviceSimulator ? 
+      MaterialApp(
+        home: DeviceSimulator(
+          brightness: Brightness.dark, 
+          enable: debugEnableDeviceSimulator, 
+          child: MaterialApp(title: 'MentorApp',
+            initialRoute: '/',
+            routes: {
+              '/': (context) => FirstRoute(),
+              '/second': (context) => SecondRoute(),
+              '/UserProfile': (context) => AppController(),
+            }
+          )
+        )
+      ) 
+    :
+      MaterialApp(
+        title: 'MentorApp',
+        initialRoute: '/',
+        routes: {
+          '/': (context) => FirstRoute(),
+          '/second': (context) => SecondRoute(),
+          '/UserProfile': (context) => AppController(),
+        },
+      );
+    return app;
   }
 }
 

--- a/mentorApp/pubspec.lock
+++ b/mentorApp/pubspec.lock
@@ -22,6 +22,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.0"
+  auto_size_text:
+    dependency: "direct main"
+    description:
+      name: auto_size_text
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/mentorApp/pubspec.lock
+++ b/mentorApp/pubspec.lock
@@ -78,6 +78,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.2"
+  custom_navigator:
+    dependency: transitive
+    description:
+      name: custom_navigator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
+  device_simulator:
+    dependency: "direct main"
+    description:
+      name: device_simulator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.6"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/mentorApp/pubspec.yaml
+++ b/mentorApp/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   curved_navigation_bar: ^0.3.2
   google_fonts: ^1.0.0
   auto_size_text: ^2.1.0
+  device_simulator: ^0.9.6
 
 dev_dependencies:
   flutter_test:

--- a/mentorApp/pubspec.yaml
+++ b/mentorApp/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   cupertino_icons: ^0.1.2
   curved_navigation_bar: ^0.3.2
   google_fonts: ^1.0.0
+  auto_size_text: ^2.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
**Changes**
- added an emulator that combines all android and apple devices
- allows for testing in different screen sizes
- moved the duplicate code in `main.dart` into its own widget called `Root`

**UI**
> No visible changes to UI, but here's a demo of the emulator added. To use it, run this on a **tablet** emulator.
> <img src="https://user-images.githubusercontent.com/23146829/81372619-0de95880-90b8-11ea-8476-15104994d786.gif" alt="A gif demoing the emulator going through various screen sizes for android and apple devices." width="600px" />