### PR TITLE
fix: section height bug

### DIFF
--- a/lib/profile/sections/sections.dart
+++ b/lib/profile/sections/sections.dart
@@ -18,7 +18,6 @@ class ProfileSections extends StatelessWidget {
     Container(
       child: Flexible(
         child: ListView(
-          padding: EdgeInsets.all(0.0),
           scrollDirection: Axis.vertical,
           shrinkWrap: true,
           children: <Widget> [

--- a/lib/profile/sections/sections.dart
+++ b/lib/profile/sections/sections.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:mentorApp/constants/navigation_constants.dart';
-import 'package:mentorApp/constants/profile_constants.dart';
 import './contact.dart';
 import './education.dart';
 import './experience.dart';
@@ -18,10 +16,11 @@ class ProfileSections extends StatelessWidget {
 
     return 
     Container(
-      height: MediaQuery.of(context).size.height - profileHeaderHeight - appNavBarHeight,
-      child: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+      child: Flexible(
+        child: ListView(
+          padding: EdgeInsets.all(0.0),
+          scrollDirection: Axis.vertical,
+          shrinkWrap: true,
           children: <Widget> [
             ProfileSummary(
               summary: data["summary"]


### PR DESCRIPTION
**Changes:**
- Fixes bug issue #66.

**Note:**
This is definitely a better alternative to making widgets scrollable in terms of responsiveness! But note that another reason why I got rid of `MediaQuery.of(context).size.height` when taking the height needed for the profile sections area was because I tested and noticed that the `device_simulator` plugin with different device sizes takes the largest available device screen as the screen height. The bug only shows up on that specific simulator and not on other individual simulators and real mobile devices. Make sure to keep that in mind when using `MediaQuery` and testing on that simulator.

**UI**
> N/A
